### PR TITLE
Remove NVM

### DIFF
--- a/roles/brew-pkgs/defaults/main.yml
+++ b/roles/brew-pkgs/defaults/main.yml
@@ -13,7 +13,6 @@ packages:
   - kubernetes-cli
   - macvim
   - make
-  - nvm
   - pyenv
   - pyyaml
   - readline

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -5,3 +5,4 @@
 #   - install arc/chrome
 #   - install iterm2/hyper
 #   - generate sshkeys ( can we also upload them manually??? )
+#   - install nvm from git


### PR DESCRIPTION
Removing NVM from the brew install list. It is not officially supported via brew and instead should be installed via a bash script. I've added a note to the todo in the setup role in order to get that working.